### PR TITLE
Fix Linux Download Path

### DIFF
--- a/backend/filename.go
+++ b/backend/filename.go
@@ -86,7 +86,6 @@ func SanitizeFolderPath(folderPath string) string {
 			continue
 		}
 
-
 		// Sanitize each folder name (but don't replace / or \ since we already normalized)
 		sanitized := sanitizeFolderName(part)
 		if sanitized != "" {


### PR DESCRIPTION
The path was being set to `Unknown/home/...` . It now correctly sets the path to `/home/...`.