### PR TITLE
Showing singular "song" if playlist or album only has one song

### DIFF
--- a/frontend/src/components/AlbumInfo.tsx
+++ b/frontend/src/components/AlbumInfo.tsx
@@ -148,7 +148,9 @@ export function AlbumInfo({
                   <span>•</span>
                   <span>{albumInfo.release_date}</span>
                   <span>•</span>
-                  <span>{albumInfo.total_tracks} songs</span>
+                  <span>
+                    {albumInfo.total_tracks} {albumInfo.total_tracks === 1 ? "song" : "songs"}
+                  </span>
                 </div>
               </div>
               <div className="flex gap-2 flex-wrap">

--- a/frontend/src/components/PlaylistInfo.tsx
+++ b/frontend/src/components/PlaylistInfo.tsx
@@ -137,7 +137,9 @@ export function PlaylistInfo({
                 <div className="flex items-center gap-2 text-sm">
                   <span className="font-medium">{playlistInfo.owner.display_name}</span>
                   <span>•</span>
-                  <span>{playlistInfo.tracks.total} songs</span>
+                  <span>
+                    {playlistInfo.tracks.total} {playlistInfo.tracks.total === 1 ? "song" : "songs"}
+                  </span>
                   <span>•</span>
                   <span>{playlistInfo.followers.total.toLocaleString()} followers</span>
                 </div>


### PR DESCRIPTION
Absolutely love this utility! This PR is the tiniest of nitpicks, just showing the singular word "song" if a playlist or album has only one item.

Also open to something in the vein of `{albumInfo.total_tracks} song{albumInfo.total_tracks !== 1 && "s"}` if that is more stylistically consistent/appropriate. Thank you!