### PR TITLE
Added a toggle to choose between using Artist property or AlbumArtist property for folder name

### DIFF
--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -339,7 +339,14 @@ export function SettingsPage() {
               </p>
             )}
           </div>
-
+            <div className="flex items-center gap-3">
+                <Label htmlFor="use-album-artist" className="cursor-pointer text-sm">Use Album Artist</Label>
+                <Switch
+                    id="use-album-artist"
+                    checked={tempSettings.useAlbumArtist}
+                    onCheckedChange={(checked) => setTempSettings(prev => ({ ...prev, useAlbumArtist: checked }))}
+                />
+            </div>
           <div className="border-t" />
 
           {/* Filename Format */}

--- a/frontend/src/hooks/useDownload.ts
+++ b/frontend/src/hooks/useDownload.ts
@@ -50,8 +50,13 @@ export function useDownload() {
     // Replace forward slashes in template data values to prevent them from being interpreted as path separators
     const placeholder = "__SLASH_PLACEHOLDER__";
     // Build template data for folder path
+    let artistFolderName = artistName;
+    if(settings.useAlbumArtist) {
+        artistFolderName = albumArtist || artistName;
+    }
+    logger.info("Using artist folder name: " + artistFolderName);
     const templateData: TemplateData = {
-      artist: artistName?.replace(/\//g, placeholder),
+      artist: artistFolderName?.replace(/\//g, placeholder),
       album: albumName?.replace(/\//g, placeholder),
       title: trackName?.replace(/\//g, placeholder),
       track: position,
@@ -296,11 +301,15 @@ export function useDownload() {
 
     let outputDir = settings.downloadPath;
     let useAlbumTrackNumber = false;
-
+      let artistFolderName = artistName;
+      if(settings.useAlbumArtist) {
+          artistFolderName = albumArtist || artistName;
+      }
+      logger.info("Using artist folder name: " + artistFolderName);
     // Replace forward slashes in template data values to prevent them from being interpreted as path separators
     const placeholder = "__SLASH_PLACEHOLDER__";
     const templateData: TemplateData = {
-      artist: artistName?.replace(/\//g, placeholder),
+      artist: artistFolderName?.replace(/\//g, placeholder),
       album: albumName?.replace(/\//g, placeholder),
       title: trackName?.replace(/\//g, placeholder),
       track: position,

--- a/frontend/src/lib/settings.ts
+++ b/frontend/src/lib/settings.ts
@@ -21,6 +21,7 @@ export interface Settings {
   filenameTemplate: string;
   // Legacy settings (kept for migration)
   filenameFormat?: "title-artist" | "artist-title" | "title";
+  useAlbumArtist?: boolean;
   artistSubfolder?: boolean;
   albumSubfolder?: boolean;
   trackNumber: boolean;


### PR DESCRIPTION
The current behavior causes compilation albums, albums with featured artists, and soundtracks, among others, to be split up rather than being grouped together in an album folder. 
By allowing the user to choose whether to use the AlbumArtist field rather than the Artist field, they can decide whether or not this splitting-up occurs.
Relevant changes made in c6d4a79398f33feef3676be666cf3f0c0cccf963, all other files should be synced to current tree.
