### PR TITLE
feat: Add CSV playlist import feature

### DIFF
--- a/backend/csv_parser.go
+++ b/backend/csv_parser.go
@@ -1,0 +1,180 @@
+package backend
+
+import (
+	"encoding/csv"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+// CSVTrack represents a track parsed from CSV
+type CSVTrack struct {
+	TrackURI    string `json:"track_uri"`
+	TrackName   string `json:"track_name"`
+	AlbumName   string `json:"album_name"`
+	ArtistName  string `json:"artist_name"`
+	ReleaseDate string `json:"release_date"`
+	DurationMs  int    `json:"duration_ms"`
+	Popularity  int    `json:"popularity"`
+	Explicit    bool   `json:"explicit"`
+	SpotifyID   string `json:"spotify_id"`
+}
+
+// ParseCSVPlaylist parses a Spotify exported CSV file
+func ParseCSVPlaylist(filePath string) ([]CSVTrack, error) {
+	fmt.Printf("\n[CSV Parser] Opening file: %s\n", filePath)
+
+	file, err := os.Open(filePath)
+	if err != nil {
+		fmt.Printf("[CSV Parser] ERROR opening file: %v\n", err)
+		return nil, fmt.Errorf("failed to open CSV file: %v", err)
+	}
+	defer file.Close()
+
+	reader := csv.NewReader(file)
+	reader.LazyQuotes = true       // Allow lazy quotes
+	reader.TrimLeadingSpace = true // Trim leading space
+
+	// Read header
+	fmt.Println("[CSV Parser] Reading header...")
+	header, err := reader.Read()
+	if err != nil {
+		fmt.Printf("[CSV Parser] ERROR reading header: %v\n", err)
+		return nil, fmt.Errorf("failed to read CSV header: %v", err)
+	}
+
+	// Clean header columns - remove BOM, trim space, and remove non-printable characters
+	for i, col := range header {
+		// Remove BOM (UTF-8 BOM is EF BB BF)
+		col = strings.TrimPrefix(col, "\uFEFF")
+		// Trim spaces
+		col = strings.TrimSpace(col)
+		// Remove any non-printable characters
+		col = strings.Map(func(r rune) rune {
+			if unicode.IsPrint(r) {
+				return r
+			}
+			return -1
+		}, col)
+		header[i] = col
+	}
+
+	fmt.Printf("[CSV Parser] Header columns (cleaned): %v\n", header)
+
+	// Find column indices
+	colMap := make(map[string]int)
+	for i, col := range header {
+		colMap[col] = i
+	}
+
+	// Verify required columns exist
+	requiredCols := []string{"Track URI", "Track Name", "Artist Name(s)"}
+	for _, col := range requiredCols {
+		if _, ok := colMap[col]; !ok {
+			fmt.Printf("[CSV Parser] ERROR: Missing required column: %s\n", col)
+			fmt.Printf("[CSV Parser] Available columns: %v\n", header)
+			return nil, fmt.Errorf("missing required column: %s", col)
+		}
+	}
+	fmt.Println("[CSV Parser] All required columns found")
+
+	var tracks []CSVTrack
+
+	// Read all rows
+	fmt.Println("[CSV Parser] Reading rows...")
+	rowCount := 0
+	for {
+		record, err := reader.Read()
+		if err != nil {
+			if err.Error() != "EOF" {
+				fmt.Printf("[CSV Parser] Error reading row %d: %v\n", rowCount+1, err)
+			}
+			break // EOF or error
+		}
+
+		rowCount++
+		if len(record) == 0 {
+			continue
+		}
+
+		track := CSVTrack{}
+
+		// Track URI (e.g., "spotify:track:7LsYnC8kNpGZSDDDulmXph")
+		if idx, ok := colMap["Track URI"]; ok && idx < len(record) {
+			track.TrackURI = strings.TrimSpace(record[idx])
+			// Extract Spotify ID from URI
+			parts := strings.Split(track.TrackURI, ":")
+			if len(parts) == 3 && parts[0] == "spotify" && parts[1] == "track" {
+				track.SpotifyID = parts[2]
+			}
+		}
+
+		// Skip if no valid Spotify ID
+		if track.SpotifyID == "" {
+			fmt.Printf("[CSV Parser] Row %d: Skipping - no valid Spotify ID\n", rowCount)
+			continue
+		}
+
+		// Track Name
+		if idx, ok := colMap["Track Name"]; ok && idx < len(record) {
+			track.TrackName = strings.TrimSpace(record[idx])
+		}
+
+		// Album Name
+		if idx, ok := colMap["Album Name"]; ok && idx < len(record) {
+			track.AlbumName = strings.TrimSpace(record[idx])
+		}
+
+		// Artist Name(s)
+		if idx, ok := colMap["Artist Name(s)"]; ok && idx < len(record) {
+			track.ArtistName = strings.TrimSpace(record[idx])
+		}
+
+		// Release Date
+		if idx, ok := colMap["Release Date"]; ok && idx < len(record) {
+			track.ReleaseDate = strings.TrimSpace(record[idx])
+		}
+
+		// Duration (ms)
+		if idx, ok := colMap["Duration (ms)"]; ok && idx < len(record) {
+			if duration, err := strconv.Atoi(strings.TrimSpace(record[idx])); err == nil {
+				track.DurationMs = duration
+			}
+		}
+
+		// Popularity
+		if idx, ok := colMap["Popularity"]; ok && idx < len(record) {
+			if popularity, err := strconv.Atoi(strings.TrimSpace(record[idx])); err == nil {
+				track.Popularity = popularity
+			}
+		}
+
+		// Explicit
+		if idx, ok := colMap["Explicit"]; ok && idx < len(record) {
+			explicit := strings.ToLower(strings.TrimSpace(record[idx]))
+			track.Explicit = explicit == "true"
+		}
+
+		tracks = append(tracks, track)
+	}
+
+	fmt.Printf("[CSV Parser] Processed %d rows, found %d valid tracks\n", rowCount, len(tracks))
+
+	if len(tracks) == 0 {
+		fmt.Println("[CSV Parser] ERROR: No valid tracks found")
+		return nil, fmt.Errorf("no valid tracks found in CSV file")
+	}
+
+	fmt.Printf("[CSV Parser] Successfully parsed %d tracks\n", len(tracks))
+	return tracks, nil
+}
+
+// CSVParseResult represents the result of parsing a CSV file
+type CSVParseResult struct {
+	Success    bool       `json:"success"`
+	TrackCount int        `json:"track_count"`
+	Tracks     []CSVTrack `json:"tracks"`
+	Error      string     `json:"error,omitempty"`
+}

--- a/backend/file_dialog.go
+++ b/backend/file_dialog.go
@@ -50,3 +50,24 @@ func SelectOutputDirectory(ctx context.Context) (string, error) {
 	return dir, nil
 }
 
+// SelectCSVFileDialog opens a file dialog to select a CSV file
+func SelectCSVFileDialog(ctx context.Context) (string, error) {
+	file, err := runtime.OpenFileDialog(ctx, runtime.OpenDialogOptions{
+		Title: "Select CSV Playlist File",
+		Filters: []runtime.FileFilter{
+			{
+				DisplayName: "CSV Files (*.csv)",
+				Pattern:     "*.csv",
+			},
+			{
+				DisplayName: "All Files (*.*)",
+				Pattern:     "*.*",
+			},
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+	return file, nil
+}
+

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -30,6 +30,7 @@ import { DownloadProgressToast } from "@/components/DownloadProgressToast";
 import { AudioAnalysisPage } from "@/components/AudioAnalysisPage";
 import { AudioConverterPage } from "@/components/AudioConverterPage";
 import { FileManagerPage } from "@/components/FileManagerPage";
+import { CSVImportPage } from "@/components/CSVImportPage";
 import { SettingsPage } from "@/components/SettingsPage";
 import { DebugLoggerPage } from "@/components/DebugLoggerPage";
 import type { HistoryItem } from "@/components/FetchHistory";
@@ -547,6 +548,8 @@ function App() {
         return <AudioConverterPage />;
       case "file-manager":
         return <FileManagerPage />;
+      case "csv-import":
+        return <CSVImportPage onDownloadTrack={download.handleDownloadTrack} />;
       default:
         return (
           <>

--- a/frontend/src/components/CSVImportPage.tsx
+++ b/frontend/src/components/CSVImportPage.tsx
@@ -1,0 +1,265 @@
+import { useState } from "react";
+import { Button } from "./ui/button";
+import { Card } from "./ui/card";
+import { Upload, FileText, Download, CheckCircle, XCircle, Loader2 } from "lucide-react";
+import { toastWithSound as toast } from "@/lib/toast-with-sound";
+import type { CSVTrack } from "@/types/api";
+import { SelectCSVFile, ParseCSVPlaylist, GetSpotifyMetadata } from "../../wailsjs/go/main/App";
+
+interface CSVImportPageProps {
+  onDownloadTrack: (
+    isrc: string,
+    name: string,
+    artists: string,
+    albumName: string,
+    spotifyId?: string,
+    folderName?: string,
+    durationMs?: number,
+    position?: number,
+    albumArtist?: string,
+    releaseDate?: string,
+    coverUrl?: string,
+    spotifyTrackNumber?: number,
+    spotifyDiscNumber?: number,
+    spotifyTotalTracks?: number
+  ) => void;
+}
+
+export function CSVImportPage({ onDownloadTrack }: CSVImportPageProps) {
+  const [csvFilePath, setCSVFilePath] = useState<string>("");
+  const [tracks, setTracks] = useState<CSVTrack[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isDownloading, setIsDownloading] = useState(false);
+  const [downloadProgress, setDownloadProgress] = useState({ current: 0, total: 0 });
+  const [downloadedTracks, setDownloadedTracks] = useState<Set<string>>(new Set());
+  const [failedTracks, setFailedTracks] = useState<Set<string>>(new Set());
+
+  const handleSelectCSV = async () => {
+    try {
+      const filePath = await SelectCSVFile();
+      if (filePath) {
+        setCSVFilePath(filePath);
+        await parseCSV(filePath);
+      }
+    } catch (err) {
+      toast.error("Failed to select CSV file");
+      console.error(err);
+    }
+  };
+
+  const parseCSV = async (filePath: string) => {
+    setIsLoading(true);
+    try {
+      const result = await ParseCSVPlaylist(filePath);
+      if (result.success && result.tracks) {
+        setTracks(result.tracks);
+        toast.success(`Loaded ${result.track_count} tracks from CSV`);
+      } else {
+        toast.error(result.error || "Failed to parse CSV file");
+      }
+    } catch (err) {
+      toast.error("Failed to parse CSV file");
+      console.error(err);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleDownloadAll = async () => {
+    if (tracks.length === 0) {
+      toast.error("No tracks to download");
+      return;
+    }
+
+    setIsDownloading(true);
+    setDownloadProgress({ current: 0, total: tracks.length });
+    setDownloadedTracks(new Set());
+    setFailedTracks(new Set());
+
+    let successCount = 0;
+    let failCount = 0;
+
+    for (let i = 0; i < tracks.length; i++) {
+      const track = tracks[i];
+      setDownloadProgress({ current: i + 1, total: tracks.length });
+
+      try {
+        // Fetch full metadata from Spotify for ISRC
+        const metadataJson = await GetSpotifyMetadata({
+          url: `https://open.spotify.com/track/${track.spotify_id}`,
+          batch: false,
+          delay: 0.5,
+          timeout: 30,
+        });
+        
+        const metadata = JSON.parse(metadataJson);
+        
+        if (metadata.track && metadata.track.isrc) {
+          const trackData = metadata.track;
+          
+          // Download the track
+          await onDownloadTrack(
+            trackData.isrc,
+            track.track_name,
+            track.artist_name,
+            track.album_name,
+            track.spotify_id,
+            undefined, // folderName
+            track.duration_ms,
+            i + 1, // position
+            trackData.album_artist,
+            track.release_date,
+            trackData.images,
+            trackData.track_number,
+            trackData.disc_number,
+            trackData.total_tracks
+          );
+
+          setDownloadedTracks((prev) => new Set(prev).add(track.spotify_id));
+          successCount++;
+        } else {
+          throw new Error("No ISRC found for track");
+        }
+      } catch (err) {
+        console.error(`Failed to download track ${track.track_name}:`, err);
+        setFailedTracks((prev) => new Set(prev).add(track.spotify_id));
+        failCount++;
+      }
+
+      // Add a small delay between tracks to avoid rate limiting
+      if (i < tracks.length - 1) {
+        await new Promise((resolve) => setTimeout(resolve, 500));
+      }
+    }
+
+    setIsDownloading(false);
+    
+    if (failCount === 0) {
+      toast.success(`Successfully downloaded all ${successCount} tracks!`);
+    } else {
+      toast.warning(`Downloaded ${successCount} tracks, ${failCount} failed`);
+    }
+  };
+
+  return (
+    <div className="p-6 space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold mb-2">CSV Playlist Import</h2>
+        <p className="text-muted-foreground">
+          Import and download tracks from a Spotify CSV export file
+        </p>
+      </div>
+
+      <Card className="p-6">
+        <div className="space-y-4">
+          <div>
+            <Button onClick={handleSelectCSV} disabled={isLoading || isDownloading}>
+              <Upload className="h-4 w-4 mr-2" />
+              Select CSV File
+            </Button>
+          </div>
+
+          {csvFilePath && (
+            <div className="flex items-center gap-2 text-sm">
+              <FileText className="h-4 w-4 text-muted-foreground" />
+              <span className="text-muted-foreground">Selected file:</span>
+              <span className="font-mono text-xs">{csvFilePath}</span>
+            </div>
+          )}
+
+          {tracks.length > 0 && (
+            <>
+              <div className="border-t pt-4">
+                <div className="flex items-center justify-between mb-4">
+                  <div>
+                    <h3 className="font-semibold">
+                      {tracks.length} tracks loaded
+                    </h3>
+                    {isDownloading && (
+                      <p className="text-sm text-muted-foreground">
+                        Progress: {downloadProgress.current} / {downloadProgress.total}
+                      </p>
+                    )}
+                  </div>
+                  <Button
+                    onClick={handleDownloadAll}
+                    disabled={isDownloading}
+                    size="lg"
+                  >
+                    {isDownloading ? (
+                      <>
+                        <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                        Downloading...
+                      </>
+                    ) : (
+                      <>
+                        <Download className="h-4 w-4 mr-2" />
+                        Download All Tracks
+                      </>
+                    )}
+                  </Button>
+                </div>
+
+                <div className="max-h-[400px] overflow-y-auto border rounded-lg">
+                  <table className="w-full">
+                    <thead className="bg-muted sticky top-0">
+                      <tr>
+                        <th className="p-3 text-left text-sm font-medium">Status</th>
+                        <th className="p-3 text-left text-sm font-medium">Track</th>
+                        <th className="p-3 text-left text-sm font-medium">Artist</th>
+                        <th className="p-3 text-left text-sm font-medium">Album</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {tracks.map((track, index) => (
+                        <tr
+                          key={track.spotify_id || index}
+                          className="border-b hover:bg-muted/30"
+                        >
+                          <td className="p-3">
+                            {downloadedTracks.has(track.spotify_id) ? (
+                              <CheckCircle className="h-4 w-4 text-green-500" />
+                            ) : failedTracks.has(track.spotify_id) ? (
+                              <XCircle className="h-4 w-4 text-red-500" />
+                            ) : isDownloading &&
+                              downloadProgress.current === index + 1 ? (
+                              <Loader2 className="h-4 w-4 animate-spin" />
+                            ) : null}
+                          </td>
+                          <td className="p-3 text-sm">{track.track_name}</td>
+                          <td className="p-3 text-sm text-muted-foreground">
+                            {track.artist_name}
+                          </td>
+                          <td className="p-3 text-sm text-muted-foreground">
+                            {track.album_name}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </>
+          )}
+
+          {isLoading && (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+            </div>
+          )}
+        </div>
+      </Card>
+
+      <Card className="p-6 bg-muted/30">
+        <h3 className="font-semibold mb-2">How to use:</h3>
+        <ol className="list-decimal list-inside space-y-2 text-sm text-muted-foreground">
+          <li>Export your Spotify playlist as a CSV file</li>
+          <li>Click "Select CSV File" to choose your exported playlist</li>
+          <li>Review the loaded tracks in the table</li>
+          <li>Click "Download All Tracks" to start the batch download</li>
+          <li>The app will fetch metadata and download each track automatically</li>
+        </ol>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { FileMusic, FilePen } from "lucide-react";
+import { FileMusic, FilePen, FileSpreadsheet } from "lucide-react";
 import { HomeIcon } from "@/components/ui/home";
 import { SettingsIcon } from "@/components/ui/settings";
 import { ActivityIcon } from "@/components/ui/activity";
@@ -14,7 +14,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { openExternal } from "@/lib/utils";
 
-export type PageType = "main" | "settings" | "debug" | "audio-analysis" | "audio-converter" | "file-manager";
+export type PageType = "main" | "settings" | "debug" | "audio-analysis" | "audio-converter" | "file-manager" | "csv-import";
 
 interface SidebarProps {
   currentPage: PageType;
@@ -107,6 +107,23 @@ export function Sidebar({ currentPage, onPageChange }: SidebarProps) {
           </TooltipTrigger>
           <TooltipContent side="right">
             <p>File Manager</p>
+          </TooltipContent>
+        </Tooltip>
+
+        {/* CSV Import */}
+        <Tooltip delayDuration={0}>
+          <TooltipTrigger asChild>
+            <Button
+              variant={currentPage === "csv-import" ? "secondary" : "ghost"}
+              size="icon"
+              className="h-10 w-10"
+              onClick={() => onPageChange("csv-import")}
+            >
+              <FileSpreadsheet className="h-5 w-5" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="right">
+            <p>CSV Playlist Import</p>
           </TooltipContent>
         </Tooltip>
 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -247,3 +247,36 @@ export interface AudioMetadata {
   disc_number: number;
   year: string;
 }
+
+export interface CSVTrack {
+  track_uri: string;
+  track_name: string;
+  album_name: string;
+  artist_name: string;
+  release_date: string;
+  duration_ms: number;
+  popularity: number;
+  explicit: boolean;
+  spotify_id: string;
+}
+
+export interface CSVParseResult {
+  success: boolean;
+  track_count: number;
+  tracks: CSVTrack[];
+  error?: string;
+}
+
+export interface CSVBatchDownloadRequest {
+  csv_file_path: string;
+  output_dir: string;
+}
+
+export interface CSVBatchDownloadResponse {
+  success: boolean;
+  message: string;
+  total_tracks: number;
+  queued_tracks: number;
+  skipped_tracks: number;
+  error?: string;
+}


### PR DESCRIPTION
## Feature: CSV Playlist Import

Adds ability to import and batch download tracks from Spotify CSV exports.

### Changes
- **Backend**: CSV parser with BOM handling
- **Frontend**: New CSV import page with file picker and progress tracking
- **Integration**: Added to sidebar navigation

### Usage
1. Export Spotify playlist as CSV
2. Click CSV icon in sidebar
3. Select CSV file
4. Click "Download All Tracks"

### Testing
Tested with Spotify CSV exports containing special characters and BOM.