### PR TITLE
Security Fix: Enforce strict validation for FFmpeg binary paths

### DIFF
--- a/backend/filemanager.go
+++ b/backend/filemanager.go
@@ -244,6 +244,10 @@ func readMetadataWithFFprobe(filePath string) (*AudioMetadata, error) {
 		return nil, err
 	}
 
+	if err := ValidateExecutable(ffprobePath); err != nil {
+		return nil, fmt.Errorf("invalid ffprobe executable: %w", err)
+	}
+
 	// Use ffprobe to get metadata in JSON format (both format and stream tags)
 	cmd := exec.Command(ffprobePath,
 		"-v", "quiet",

--- a/backend/metadata.go
+++ b/backend/metadata.go
@@ -541,6 +541,10 @@ func embedLyricsToM4A(filepath string, lyrics string) error {
 		return fmt.Errorf("ffmpeg not found: %w", err)
 	}
 
+	if err := ValidateExecutable(ffmpegPath); err != nil {
+		return fmt.Errorf("invalid ffmpeg executable: %w", err)
+	}
+
 	// Create temporary output file with proper extension so ffmpeg can detect format
 	tmpOutputFile := strings.TrimSuffix(filepath, pathfilepath.Ext(filepath)) + ".tmp" + pathfilepath.Ext(filepath)
 	defer func() {


### PR DESCRIPTION
Fixes a potential command injection vulnerability by enforcing strict validation on external binary paths.

Previously, `exec.Command` accepted paths without verification, creating an attack vector if variables were compromised. I've introduced a `ValidateExecutable` function to ensure that:
1. Paths are absolute and point to existing files.
2. Files have executable permissions (on *nix).
3. Filenames match strictly allowlisted binaries (`ffmpeg`, `ffprobe`).

This validation is now applied across `ffmpeg.go`, `filemanager.go`, and `metadata.go` before any subprocess execution.