### PR TITLE
docs: Add SpotiFLAC Mobile to Other Projects section

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,10 @@ Get Spotify tracks in true FLAC from Tidal, Qobuz & Amazon Music — no account 
 
 ## Other project
 
-### [SpotiDownloader](https://github.com/afkarxyz/SpotiDownloader) 
+### [SpotiFLAC Mobile](https://github.com/zarzet/SpotiFLAC-Mobile)
+Mobile port of SpotiFLAC for Android & iOS — maintained by [@zarzet](https://github.com/zarzet)
 
+### [SpotiDownloader](https://github.com/afkarxyz/SpotiDownloader) 
 Get Spotify tracks in MP3 and FLAC via the spotidownloader.com API
 
 [![Ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/afkarxyz)


### PR DESCRIPTION
Hi @afkarxyz! 👋

I've created a mobile port of SpotiFLAC for Android & iOS using Flutter. The app uses the same Go backend logic and provides the same functionality on mobile devices.

**Features:**
- Download Spotify tracks in FLAC from Tidal, Qobuz & Amazon Music
- Support for single tracks, albums, and playlists
- Material 3 design with dynamic color support
- Works on Android 7.0+ and iOS 14.0+

**Repository:** https://github.com/zarzet/SpotiFLAC-Mobile

I've already credited your original project in my app's Settings screen and README. Would you be open to adding a link to the mobile version in your README?

Thank you for creating this awesome project! 🙏
