### PR TITLE
Update main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,8 +21,8 @@ func main() {
 		Title:     "SpotiFLAC",
 		Width:     1024,
 		Height:    600,
-		MinWidth:  1024,
-		MinHeight: 600,
+		MinWidth:  400,
+		MinHeight: 300,
 		Frameless: true,
 		AssetServer: &assetserver.Options{
 			Assets: assets,


### PR DESCRIPTION
Updated: MinWidth and MinHeight.
The app was covering more than half screen on smaller screens like laptop while using tiling window manager caused by same values in Width, Height and MinWidth, MinHeight respectively, due to which other apps were not getting space.

Now you can reduce the window size even more than previous version.
