### PR TITLE
fix: add year field to lyrics and cover download template data

### DIFF
--- a/frontend/src/hooks/useCover.ts
+++ b/frontend/src/hooks/useCover.ts
@@ -28,11 +28,13 @@ export function useCover() {
             const os = settings.operatingSystem;
             let outputDir = settings.downloadPath;
             const placeholder = "__SLASH_PLACEHOLDER__";
+            const yearValue = releaseDate?.substring(0, 4);
             const templateData: TemplateData = {
                 artist: artistName?.replace(/\//g, placeholder),
                 album: albumName?.replace(/\//g, placeholder),
                 title: trackName?.replace(/\//g, placeholder),
                 track: position,
+                year: yearValue,
                 playlist: playlistName?.replace(/\//g, placeholder),
             };
             const folderTemplate = settings.folderTemplate || "";
@@ -124,11 +126,13 @@ export function useCover() {
                 const placeholder = "__SLASH_PLACEHOLDER__";
                 const useAlbumTrackNumber = settings.folderTemplate?.includes("{album}") || false;
                 const trackPosition = useAlbumTrackNumber ? (track.track_number || i + 1) : (i + 1);
+                const yearValue = track.release_date?.substring(0, 4);
                 const templateData: TemplateData = {
                     artist: track.artists?.replace(/\//g, placeholder),
                     album: track.album_name?.replace(/\//g, placeholder),
                     title: track.name?.replace(/\//g, placeholder),
                     track: trackPosition,
+                    year: yearValue,
                     playlist: playlistName?.replace(/\//g, placeholder),
                 };
                 const folderTemplate = settings.folderTemplate || "";

--- a/frontend/src/hooks/useLyrics.ts
+++ b/frontend/src/hooks/useLyrics.ts
@@ -25,11 +25,13 @@ export function useLyrics() {
             const os = settings.operatingSystem;
             let outputDir = settings.downloadPath;
             const placeholder = "__SLASH_PLACEHOLDER__";
+            const yearValue = releaseDate?.substring(0, 4);
             const templateData: TemplateData = {
                 artist: artistName?.replace(/\//g, placeholder),
                 album: albumName?.replace(/\//g, placeholder),
                 title: trackName?.replace(/\//g, placeholder),
                 track: position,
+                year: yearValue,
                 playlist: playlistName?.replace(/\//g, placeholder),
             };
             const folderTemplate = settings.folderTemplate || "";
@@ -120,11 +122,13 @@ export function useLyrics() {
                 const placeholder = "__SLASH_PLACEHOLDER__";
                 const useAlbumTrackNumber = settings.folderTemplate?.includes("{album}") || false;
                 const trackPosition = useAlbumTrackNumber ? (track.track_number || i + 1) : (i + 1);
+                const yearValue = track.release_date?.substring(0, 4);
                 const templateData: TemplateData = {
                     artist: track.artists?.replace(/\//g, placeholder),
                     album: track.album_name?.replace(/\//g, placeholder),
                     title: track.name?.replace(/\//g, placeholder),
                     track: trackPosition,
+                    year: yearValue,
                     playlist: playlistName?.replace(/\//g, placeholder),
                 };
                 const folderTemplate = settings.folderTemplate || "";


### PR DESCRIPTION
- Extract year from releaseDate using substring(0, 4) in both hooks
- Add year field to templateData in single download functions
- Add year field to templateData in bulk download functions
- Allows parseTemplate() to correctly replace {year} placeholder instead of defaulting to '0000'
- Fixes folder structure generation when year is used in filename or folder templates