### PR TITLE
docs: Add SpotiFLAC Python Module to Other Projects section

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ SpotiFLAC for Android & iOS — maintained by [@zarzet](https://github.com/zarze
 
 SpotiFLAC for command-line environments — maintained by [@Nizarberyan](https://github.com/Nizarberyan)
 
+### [SpotiFLAC (Python Module)](https://github.com/ShuShuzinhuu/SpotiFLAC-Module-Version)
+
+SpotiFLAC Python library for SpotiFLAC integration — maintained by [@ShuShuzinhuu](https://github.com/ShuShuzinhuu)
+
 ## FAQ
 
 ### Is this software free?


### PR DESCRIPTION
Hi @afkarxyz!

I created a version of SpotiFLAC for Python. Great for including in projects, especially for beginners.

**Freatures:**
- Download Spotify tracks in FLAC from Tidal, Qobuz & Amazon Music
- Support for single tracks, albums, and playlists
- CLI suport
- It works on any device that has Python

**Repository:** https://github.com/ShuShuzinhuu/SpotiFLAC-Module-Version

I've already mentioned your original project in my app's settings and README file. Would you mind adding a link to the mobile version in your README?

Thank you, your project has greatly encouraged me, and I want to provide support for the Python version of this project.