### PR TITLE
feat(settings): add option to disable existing file check (#848)

### DIFF
--- a/backend/amazon.go
+++ b/backend/amazon.go
@@ -303,7 +303,7 @@ func (a *AmazonDownloader) DownloadByURL(amazonURL, outputDir, quality, filename
 		expectedFilename := BuildExpectedFilename(spotifyTrackName, filenameArtist, spotifyAlbumName, filenameAlbumArtist, spotifyReleaseDate, filenameFormat, playlistName, playlistOwner, includeTrackNumber, position, spotifyDiscNumber, false, isrcOverride)
 		expectedPath := filepath.Join(outputDir, expectedFilename)
 
-		if !GetRedownloadWithSuffixSetting() {
+		if !GetRedownloadWithSuffixSetting() && !ExistingFileCheckDisabled() {
 			if fileInfo, err := os.Stat(expectedPath); err == nil && fileInfo.Size() > 0 {
 				fmt.Printf("File already exists: %s (%.2f MB)\n", expectedPath, float64(fileInfo.Size())/(1024*1024))
 				return "EXISTS:" + expectedPath, nil

--- a/backend/config.go
+++ b/backend/config.go
@@ -79,6 +79,8 @@ func normalizeExistingFileCheckMode(value string) string {
 	switch strings.TrimSpace(strings.ToLower(value)) {
 	case "isrc", "upc":
 		return "isrc"
+	case "none", "off", "disabled":
+		return "none"
 	default:
 		return "filename"
 	}
@@ -92,6 +94,10 @@ func GetExistingFileCheckModeSetting() string {
 
 	rawMode, _ := settings["existingFileCheckMode"].(string)
 	return normalizeExistingFileCheckMode(rawMode)
+}
+
+func ExistingFileCheckDisabled() bool {
+	return GetExistingFileCheckModeSetting() == "none"
 }
 
 func GetLinkResolverSetting() string {

--- a/backend/filename.go
+++ b/backend/filename.go
@@ -82,6 +82,10 @@ func BuildExpectedFilename(trackName, artistName, albumName, albumArtist, releas
 }
 
 func ResolveOutputPathForDownload(path string, redownloadWithSuffix bool) (string, bool) {
+	if ExistingFileCheckDisabled() {
+		return path, false
+	}
+
 	if !redownloadWithSuffix {
 		if info, err := os.Stat(path); err == nil && info.Size() > 0 {
 			return path, true

--- a/backend/qobuz.go
+++ b/backend/qobuz.go
@@ -695,7 +695,7 @@ func (q *QobuzDownloader) DownloadTrackWithISRC(isrc, outputDir, quality, filena
 	filename := buildQobuzFilename(safeTitle, safeArtist, safeAlbum, safeAlbumArtist, spotifyReleaseDate, spotifyTrackNumber, spotifyDiscNumber, filenameFormat, includeTrackNumber, position, useAlbumTrackNumber, isrc)
 	filepath := filepath.Join(outputDir, filename)
 	filepath, alreadyExists := ResolveOutputPathForDownload(filepath, GetRedownloadWithSuffixSetting())
-	if alreadyExists {
+	if alreadyExists && !ExistingFileCheckDisabled() {
 		fmt.Printf("File already exists: %s (%.2f MB)\n", filepath, float64(mustFileSize(filepath))/(1024*1024))
 		return "EXISTS:" + filepath, nil
 	}

--- a/backend/tidal.go
+++ b/backend/tidal.go
@@ -583,7 +583,7 @@ func (t *TidalDownloader) DownloadByURL(tidalURL, outputDir, quality, filenameFo
 	if err != nil {
 		return "", err
 	}
-	if alreadyExists {
+	if alreadyExists && !ExistingFileCheckDisabled() {
 		fmt.Printf("File already exists: %s (%.2f MB)\n", outputFilename, float64(mustFileSize(outputFilename))/(1024*1024))
 		return "EXISTS:" + outputFilename, nil
 	}
@@ -635,7 +635,7 @@ func (t *TidalDownloader) DownloadByURLWithFallback(tidalURL, outputDir, quality
 	if err != nil {
 		return "", err
 	}
-	if alreadyExists {
+	if alreadyExists && !ExistingFileCheckDisabled() {
 		fmt.Printf("File already exists: %s (%.2f MB)\n", outputFilename, float64(mustFileSize(outputFilename))/(1024*1024))
 		return "EXISTS:" + outputFilename, nil
 	}

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -779,6 +779,7 @@ export function SettingsPage({ onUnsavedChangesChange, onResetRequest, }: Settin
                   <SelectContent>
                     <SelectItem value="filename">Filename</SelectItem>
                     <SelectItem value="isrc">ISRC</SelectItem>
+                    <SelectItem value="none">Disabled</SelectItem>
                   </SelectContent>
                 </Select>
               </div>

--- a/frontend/src/lib/settings.ts
+++ b/frontend/src/lib/settings.ts
@@ -16,7 +16,7 @@ export type FontOption = {
 };
 export type FolderPreset = "none" | "artist" | "album" | "year-album" | "year-artist-album" | "artist-album" | "artist-year-album" | "artist-year-nested-album" | "album-artist" | "album-artist-album" | "album-artist-year-album" | "album-artist-year-nested-album" | "year" | "year-artist" | "custom";
 export type FilenamePreset = "title" | "title-artist" | "artist-title" | "track-title" | "track-title-artist" | "track-artist-title" | "title-album-artist" | "track-title-album-artist" | "artist-album-title" | "track-dash-title" | "disc-track-title" | "disc-track-title-artist" | "custom";
-export type ExistingFileCheckMode = "filename" | "isrc";
+export type ExistingFileCheckMode = "filename" | "isrc" | "none";
 export interface Settings {
     downloadPath: string;
     downloader: "auto" | "tidal" | "qobuz" | "amazon";
@@ -526,6 +526,10 @@ function normalizeExistingFileCheckMode(mode: unknown): ExistingFileCheckMode {
         case "isrc":
         case "upc":
             return "isrc";
+        case "none":
+        case "off":
+        case "disabled":
+            return "none";
         default:
             return "filename";
     }


### PR DESCRIPTION
## Summary

Adds a third value (`none`) to the `existingFileCheckMode` setting, exposed in the Settings UI as **Disabled**. When selected, the app no longer skips a track because a file with the same name already exists on disk, so the same track can be downloaded into multiple playlist folders.

## Behavior

- `filename` (default) and `isrc` modes are unchanged.
- `none` short-circuits `ResolveOutputPathForDownload` to always return `(path, false)`, bypasses the existing-file early returns in the Qobuz, Tidal and Amazon download paths, and disables the `_NN` suffix renaming.
- Configs that set the value to `off` or `disabled` are normalized to `none` for forward-compatibility.

## Test notes

- `go build ./...` and `go vet ./backend/...` pass.
- Manual: with the option set to **Disabled**, downloading a playlist that contains a track already on disk re-downloads the file instead of skipping it. With **Filename** or **ISRC** the previous behavior is preserved.

Closes #848