### PR TITLE
feat(metadata): write source URL into dedicated tag (#605)

### DIFF
--- a/backend/metadata.go
+++ b/backend/metadata.go
@@ -171,6 +171,9 @@ func EmbedMetadata(filepath string, metadata Metadata, coverPath string) error {
 	if metadata.UPC != "" {
 		_ = cmt.Add(preferredUPCTagKey, metadata.UPC)
 	}
+	if sourceURL := strings.TrimSpace(metadata.URL); sourceURL != "" {
+		_ = cmt.Add("SOURCE", sourceURL)
+	}
 
 	if genreValues := SplitMetadataValues(metadata.Genre, separator); len(genreValues) > 0 {
 		addVorbisTagValues(cmt, "GENRE", genreValues)
@@ -1098,6 +1101,16 @@ func embedMetadataToMP3(filePath string, metadata Metadata, coverPath string) er
 		})
 	}
 
+	if sourceURL := strings.TrimSpace(metadata.URL); sourceURL != "" {
+		tag.DeleteFrames("WOAS")
+		tag.AddFrame("WOAS", id3v2.UnknownFrame{Body: []byte(sourceURL)})
+		tag.AddUserDefinedTextFrame(id3v2.UserDefinedTextFrame{
+			Encoding:    id3v2.EncodingUTF8,
+			Description: "SOURCE",
+			Value:       sourceURL,
+		})
+	}
+
 	if comment := resolveMetadataComment(metadata); comment != "" {
 		tag.DeleteFrames(tag.CommonID("Comments"))
 		tag.AddCommentFrame(id3v2.CommentFrame{
@@ -1228,6 +1241,9 @@ func embedMetadataToM4A(filePath string, metadata Metadata, coverPath string) er
 	}
 	if comment := resolveMetadataComment(metadata); comment != "" {
 		args = append(args, "-metadata", "comment="+comment)
+	}
+	if sourceURL := strings.TrimSpace(metadata.URL); sourceURL != "" {
+		args = append(args, "-metadata", "source="+sourceURL)
 	}
 
 	tmpOutputFile := strings.TrimSuffix(filePath, pathfilepath.Ext(filePath)) + ".tmp" + pathfilepath.Ext(filePath)


### PR DESCRIPTION
## Summary

Adds the originating source URL of each download to a dedicated metadata tag in addition to the existing `COMMENT` fallback, so library managers (MusicBrainz Picard, Beets, foobar2000, etc.) can read where the file came from.

## Changes
- **FLAC**: write Vorbis `SOURCE` tag when `metadata.URL` is non-empty.
- **MP3**: write the standard ID3v2 `WOAS` (Official audio source webpage) URL frame, plus a `TXXX` user-defined frame with description `SOURCE` for maximum tagger compatibility (Picard/Beets).
- **M4A**: pass `-metadata source=<url>` to ffmpeg.

The existing `COMMENT`/`COMM`/`comment` fallback behavior (URL written into the comment when no explicit comment is set) is preserved, so users relying on it are not affected. The new source tag is only written when `metadata.URL` is non-empty.

## Notes
- The `bogem/id3v2` library does not expose a typed URL link frame, so `WOAS` is written via `AddFrame("WOAS", id3v2.UnknownFrame{Body: []byte(url)})`, which produces a spec-compliant URL link frame body (raw URL bytes, no encoding byte).
- Diff is minimal (3 small additions in `backend/metadata.go`).

## Test
- `go build ./...` ✅
- `go vet ./backend/...` ✅

Closes #605