### PR TITLE
fix(filecheck): skip existence check and UI badge when mode is none

### DIFF
--- a/app.go
+++ b/app.go
@@ -1890,6 +1890,19 @@ func (a *App) CheckFilesExistence(outputDir string, rootDir string, tracks []Che
 	redownloadWithSuffix := backend.GetRedownloadWithSuffixSetting()
 	existingFileCheckMode := backend.GetExistingFileCheckModeSetting()
 	scanRoot := outputDir
+
+	if existingFileCheckMode == "none" {
+		results := make([]CheckFileExistenceResult, len(tracks))
+		for i, t := range tracks {
+			results[i] = CheckFileExistenceResult{
+				SpotifyID:  t.SpotifyID,
+				TrackName:  t.TrackName,
+				ArtistName: t.ArtistName,
+				Exists:     false,
+			}
+		}
+		return results
+	}
 	if rootDir != "" {
 		scanRoot = rootDir
 	}

--- a/frontend/src/hooks/useDownload.ts
+++ b/frontend/src/hooks/useDownload.ts
@@ -154,7 +154,7 @@ export function useDownload(region: string) {
         }
         const serviceForCheck = service === "auto" ? "flac" : (service === "tidal" ? "flac" : (service === "qobuz" ? "flac" : "flac"));
         let fileExists = false;
-        if (trackName && artistName) {
+        if (trackName && artistName && settings.existingFileCheckMode !== "none") {
             try {
                 const checkRequest: CheckFileExistenceRequest = {
                     spotify_id: spotifyId || id,
@@ -779,7 +779,9 @@ export function useDownload(region: string) {
                 audio_format: audioFormat,
             };
         });
-        const existenceResults = await CheckFilesExistence(outputDir, settings.downloadPath, existenceChecks);
+        const existenceResults = settings.existingFileCheckMode !== "none"
+            ? await CheckFilesExistence(outputDir, settings.downloadPath, existenceChecks)
+            : [];
         const existingSpotifyIDs = new Set<string>();
         const existingFilePaths = new Map<string, string>();
         const finalFilePaths = new Map<string, string>();
@@ -954,7 +956,9 @@ export function useDownload(region: string) {
                 audio_format: audioFormat,
             };
         });
-        const existenceResults = await CheckFilesExistence(outputDir, settings.downloadPath, existenceChecks);
+        const existenceResults = settings.existingFileCheckMode !== "none"
+            ? await CheckFilesExistence(outputDir, settings.downloadPath, existenceChecks)
+            : [];
         const finalFilePaths: string[] = new Array(tracksWithId.length).fill("");
         const existingSpotifyIDs = new Set<string>();
         const existingFilePaths = new Map<string, string>();

--- a/frontend/src/lib/settings.ts
+++ b/frontend/src/lib/settings.ts
@@ -16,7 +16,7 @@ export type FontOption = {
 };
 export type FolderPreset = "none" | "artist" | "album" | "year-album" | "year-artist-album" | "artist-album" | "artist-year-album" | "artist-year-nested-album" | "album-artist" | "album-artist-album" | "album-artist-year-album" | "album-artist-year-nested-album" | "year" | "year-artist" | "custom";
 export type FilenamePreset = "title" | "title-artist" | "artist-title" | "track-title" | "track-title-artist" | "track-artist-title" | "title-album-artist" | "track-title-album-artist" | "artist-album-title" | "track-dash-title" | "disc-track-title" | "disc-track-title-artist" | "custom";
-export type ExistingFileCheckMode = "filename" | "isrc";
+export type ExistingFileCheckMode = "none" | "filename" | "isrc";
 export interface Settings {
     downloadPath: string;
     downloader: "auto" | "tidal" | "qobuz" | "amazon";
@@ -523,6 +523,8 @@ function normalizeCustomTidalApi(value: unknown): string {
 }
 function normalizeExistingFileCheckMode(mode: unknown): ExistingFileCheckMode {
     switch (typeof mode === "string" ? mode.trim().toLowerCase() : "") {
+        case "none":
+            return "none";
         case "isrc":
         case "upc":
             return "isrc";


### PR DESCRIPTION
Follow-up to #848 (disable filecheck).

When `existingFileCheckMode` is set to `"none"`, the backend still performed the full existence lookup and returned `Exists: true`, causing the "already exists" yellow badge to remain in the UI even though the download proceeded normally.

**Changes:**
- **Backend** (`app.go`): early return `Exists: false` for all tracks when mode is `"none"`
- **Frontend** (`useDownload.ts`): skip the 3 `CheckFilesExistence` Wails calls when mode is `"none"`
- **Frontend** (`settings.ts`): extend `ExistingFileCheckMode` type and `normalizeExistingFileCheckMode` to include `"none"`

Build and vet pass.